### PR TITLE
Update CsvFormatter.php

### DIFF
--- a/src/Omniphx/Forrest/Formatters/CsvFormatter.php
+++ b/src/Omniphx/Forrest/Formatters/CsvFormatter.php
@@ -47,8 +47,14 @@ class CsvFormatter implements FormatterInterface
     public function formatResponse($response)
     {
         $body = $response->getBody();
+        $header = $response->getHeaders();
         $contents = (string) $body;
-        return $contents;
+        
+        return [ 
+            'header' => $header,
+            'body' => $contents,
+            
+        ];
     }
 
     public function getDefaultMIMEType()


### PR DESCRIPTION
For Bulk Queries with CSVs that rely on chunking, users may need to return headers with the following values: 

'Sforce-Limit-Info' => 
'Sforce-Locator' => 
'Sforce-NumberOfRecords' => 

This proposed change would allow that.

If this would be a breaking change for other instances reading CSV data or too risky, Could there perhaps include a separate formatter for "CSV" such as "csv-headers" or others with "*-headers"?  

For example: 

```
$data = Forrest::get(
          "/services/data/v59.0/jobs/query/" . $bulkJob["id"] . "/results?maxRecords=5",
          [],
          [
              "format" => "csv",
              "Accept" => "text/csv"
          ]
      );
```
      
Will only return a CSV with 5 rows in the `$data` attribute.  Sending the headers of this request will allow you to loop while "Sforce-Locator" is set to retrieve all rows.  
     
     
     
     